### PR TITLE
Streamline install / build / remove using GNU Make

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,105 +1,109 @@
 # Installation
-<details>
-  <summary>
-    Prerequisites: Install <a href="https://github.com/lm-sensors/lm-sensors">lm_sensors</a> package (Click to expand)
-  </summary>
-  
-  ### Arch Linux
-  ```
-  sudo pacman -Syy lm_sensors
-  ```
-  ### Debian/Ubuntu Linux
-  ```
-  sudo apt update
-  ```
-  ```
-  sudo apt install lm-sensors
-  ```
-  ### Fedora Linux
-  ```
-  sudo dnf install lm_sensors
-  ```
-  ### Red Hat Enterprise Linux
-  ```
-  sudo yum install lm_sensors
-  ```
-  ### OpenSUSE Linux
-  ```
-  sudo zypper install sensors
-  ```
-  ### Gentoo Linux
-  <details>
-    <summary>
-      Install as a dependency
-    </summary>
-    
-  ##### Add these USE Flags in `/etc/portage/make.conf`:
-  `contrib`\
-  `sensord`\
-  `static-libs`
-  ##### Emerge
-  ```
-  sudo emerge --ask --changed-use --deep @world
-  ```
-  </details>
-  
-  OR
-  
-  <details>
-    <summary>
-      Install directly
-    </summary>
-    
-  ```
-  sudo emerge --ask sys-apps/lm-sensors
-  ```
-  </details>
-  
-  ### Alpine Linux
-  ```
-  sudo apk_add lm_sensors lm_sensors-detect perl
-  ```
-  ```
-  sudo tee /etc/modules-load.d/i2c.conf <<< i2c-dev
-  ```
-  ```
-  sudo modprobe i2c-dev
-  ```
-  ```
-  sudo rc-update add lm_sensors default
-  ```
-  ```
-  sudo rc-update add sensord default
-  ```
-  ```
-  sudo /etc/init.d/lm_sensors start && sudo /etc/init.d/sensord start
-  ```
-  ```
-  sudo lbu commit
-  ```
 
-</details>
+## Prerequisites
 
+Install the following packages:
+
+- [lm_sensors](https://github.com/lm-sensors/lm-sensors)
+- `make`
+
+### Arch Linux
+
+```shell
+sudo pacman -Syy lm_sensors make
+```
+
+### Debian/Ubuntu Linux
+
+```shell
+sudo apt update
+sudo apt install lm-sensors make
+```
+
+### Fedora Linux
+
+```shell
+sudo dnf install lm_sensors make
+```
+
+### Red Hat Enterprise Linux
+
+```shell
+sudo yum install lm_sensors make
+```
+
+### OpenSUSE Linux
+
+```shell
+sudo zypper install sensors make
+```
+
+### Gentoo Linux
+
+#### Install as a dependency
+
+1. Add these USE flags in `/etc/portage/make.conf`:
+
+   ```
+   contrib
+   sensord
+   static-libs
+   ```
+
+2. Emerge:
+
+   ```shell
+   sudo emerge --ask --changed-use --deep @world
+   ```
+
+#### OR Install directly
+
+```shell
+sudo emerge --ask sys-apps/lm-sensors
+```
+
+### Alpine Linux
+
+```shell
+sudo apk add lm_sensors lm_sensors-detect perl make
+```
+
+```shell
+sudo tee /etc/modules-load.d/i2c.conf <<< i2c-dev
+```
+
+```shell
+sudo modprobe i2c-dev
+```
+
+```shell
+sudo rc-update add lm_sensors default
+```
+
+```shell
+sudo rc-update add sensord default
+```
+
+```shell
+sudo /etc/init.d/lm_sensors start && sudo /etc/init.d/sensord start
+```
+
+```shell
+sudo lbu commit
+```
 
 ## Install asus-fan-mode
-> Run the following in terminal:
-```
+
+Run the following commands in the terminal:
+
+```shell
 git clone https://github.com/Arkapravo-Ghosh/asus-fan-mode.git
 ```
-```
+
+```shell
 cd asus-fan-mode
 ```
-```
-sudo pip3 install -r requirements.txt
-```
-```
-./install.sh
-```
-### Create a config file
-```
-sudo fan-mode --setup
-```
 
-> Run the command `fan-mode` to launch the program.\
-> To uninstall, run [`./uninstall.sh`](uninstall.sh) in terminal.
-
+```shell
+make install
+```

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ install: compile
 	sudo cp -r $(DIST_DIR) /opt/$(TARGET_NAME)
 	sudo ln -s /opt/$(TARGET_NAME)/$(TARGET_NAME) /usr/bin/$(TARGET_NAME)
 	sudo cp $(SYSTEMD_SERVICE) /etc/systemd/system/
+	sudo $(TARGET_NAME) --setup
 	sudo systemctl daemon-reload
+	sudo systemctl enable --now $(SYSTEMD_SERVICE)
 	@echo "Installation complete."
 
 remove:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+TARGET_NAME := fan-mode
+PYINSTALLER_FLAGS := --noconfirm --onedir --windowed src/main.py --name $(TARGET_NAME)
+DIST_DIR := dist/$(TARGET_NAME)
+BUILD_DIR := build
+SPEC_FILE := $(TARGET_NAME).spec
+SYSTEMD_SERVICE := $(TARGET_NAME)-recovery.service
+REQUIRED_SYSTEM_TOOLS := python3 objdump
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "Usage: make [target]\n"
+	@echo "  clean  	Clean all the build files."
+	@echo "  compile	Compile the program."
+	@echo "  install	Install the program."
+	@echo "  remove 	Uninstall the program."
+	@echo "  check  	Check for required tools."
+
+check:
+	@missing_tools=; \
+	for tool in $(REQUIRED_SYSTEM_TOOLS); do \
+		if ! command -v $$tool >/dev/null 2>&1; then \
+			missing_tools="$$missing_tools $$tool"; \
+		fi; \
+	done; \
+	if [ -n "$$missing_tools" ]; then \
+		echo "Error: The following tools are missing:$$missing_tools"; \
+		exit 1; \
+	else \
+		echo "All required system tools are available."; \
+	fi
+
+clean:
+	@echo "Cleaning..."
+	@rm -rf dist $(BUILD_DIR) $(SPEC_FILE)
+	@echo "Clean complete."
+
+compile: check
+	@echo "Compiling..."
+	@python3 -m venv .venv && \
+	. .venv/bin/activate && \
+	pip3 install pyinstaller && \
+	pyinstaller $(PYINSTALLER_FLAGS) && \
+	echo "Compiled. Check '$(DIST_DIR)' for the binary and '$(BUILD_DIR)' for the build files."
+
+install: compile
+	@echo "Installing..."
+	sudo rm -rf /opt/$(TARGET_NAME) /usr/bin/$(TARGET_NAME)
+	sudo cp -r $(DIST_DIR) /opt/$(TARGET_NAME)
+	sudo ln -s /opt/$(TARGET_NAME)/$(TARGET_NAME) /usr/bin/$(TARGET_NAME)
+	sudo cp $(SYSTEMD_SERVICE) /etc/systemd/system/
+	sudo systemctl daemon-reload
+	@echo "Installation complete."
+
+remove:
+	@echo "Removing..."
+	sudo systemctl disable --now $(SYSTEMD_SERVICE)
+	sudo rm -rf /opt/$(TARGET_NAME) /usr/bin/$(TARGET_NAME) /etc/fan-mode.conf /etc/systemd/system/$(SYSTEMD_SERVICE)
+	@echo "Removal complete."

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ REQUIRED_SYSTEM_TOOLS := python3 objdump
 
 help:
 	@echo "Usage: make [target]\n"
-	@echo "  clean  	Clean all the build files."
-	@echo "  compile	Compile the program."
+	@echo "  clean  	Remove all the build artifacts."
+	@echo "  build		Build the program executable."
 	@echo "  install	Install the program."
-	@echo "  remove 	Uninstall the program."
+	@echo "  remove 	Remove the program and config files."
 	@echo "  check  	Check for required tools."
 
 check:
@@ -33,9 +33,8 @@ check:
 clean:
 	@echo "Cleaning..."
 	@rm -rf dist $(BUILD_DIR) $(SPEC_FILE)
-	@echo "Clean complete."
 
-compile: check
+build: check
 	@echo "Compiling..."
 	@python3 -m venv .venv && \
 	. .venv/bin/activate && \
@@ -43,7 +42,7 @@ compile: check
 	pyinstaller $(PYINSTALLER_FLAGS) && \
 	echo "Compiled. Check '$(DIST_DIR)' for the binary and '$(BUILD_DIR)' for the build files."
 
-install: compile
+install: build
 	@echo "Installing..."
 	sudo rm -rf /opt/$(TARGET_NAME) /usr/bin/$(TARGET_NAME)
 	sudo cp -r $(DIST_DIR) /opt/$(TARGET_NAME)

--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
 # asus-fan-mode
+
 Fan Mode Control for Asus Vivobook 14X Pro OLED in Linux
 
 ![](https://img.shields.io/github/license/Arkapravo-Ghosh/asus-fan-mode)
 ![](https://img.shields.io/badge/platform-Linux-blue)
 
-* [Click Here](src/main.py) for Source code.
+- [Click Here](src/main.py) for Source code.
 
 ## Installation
+
 > Installation Guide is written in [INSTALLATION.md](INSTALLATION.md).
 
 ## Usage
-* `sudo fan-mode --auto` - Automatically optimise fan speed as per usage
-* `sudo fan-mode --full` - Force fan to run in full speed
-* `fan-mode --status` - Get status of fan
-* `fan-mode --setup` - To generate a default configuration file
-> Use `fan-mode --help` for more information.
+
+- `sudo fan-mode --auto` - Automatically optimise fan speed as per usage
+- `sudo fan-mode --full` - Force fan to run in full speed
+- `fan-mode --status` - Get status of fan
+- `fan-mode --setup` - To generate a default configuration file
+- `fan-mode --help` for more information.
 
 ## Disabling Automatic Recovery of Fan Mode on Reboot
-* `sudo systemctl disable fan-mode-recovery`
 
-## Misc
-* [`clean.sh`](clean.sh) - Execute this script to automatically clean all build files created while compiling or installing the project. This does not uninstall the program.
-* [`compile.sh`](compile.sh) - Execute this script to automatically compile the project. This does not install the program.
-> NOTE: Please run `sudo pip3 install -r requirements.txt` in the repo directory before using this script if you have not installed the dependencies of this project yet.
+- `sudo systemctl disable --now fan-mode-recovery`
+
+## Make Options
+
+- **clean** - Clean all the build artifacts.
+- **compile** - Compile the program.
+- **install** - Install the program.
+- **remove** - Remove the program.
+- **check** - Check for required tools.
 
 ### Known Issues
-* GPU Fan Controlling is not supported yet.
+
+- GPU Fan Controlling is not supported yet.

--- a/clean.sh
+++ b/clean.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-while true; do
-    read -p "Do you wish to clean all the build files? [y/N]: " yn
-    case $yn in
-        [Yy]* ) echo "Cleaning..." && rm -rf dist build fan-mode.spec && echo "Done."; break;;
-        [Nn]* ) echo "Aborted."; exit;;
-        * ) echo "Aborted."; exit;;
-    esac
-done

--- a/compile.sh
+++ b/compile.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-while true; do
-    read -p "Do you wish to install this program? [y/N]: " yn
-    case $yn in
-        [Yy]* ) echo "Compiling..."; rm -rf build dist fan-mode.spec; pyinstaller --noconfirm --onedir --windowed src/main.py --name fan-mode; echo "Compiled. Check 'dist/fan-mode' directory for the compiled binary and 'build' directory for the build files."; break;;
-        [Nn]* ) echo "Aborted."; exit;;
-        * ) echo "Aborted."; exit;;
-    esac
-done

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-while true; do
-    read -p "Do you wish to install this program? [y/N]: " yn
-    case $yn in
-        [Yy]* ) echo "Installing..."; rm -rf build dist fan-mode.spec; pyinstaller --noconfirm --onedir --windowed src/main.py --name fan-mode; sudo rm -rf /opt/fan-mode /usr/bin/fan-mode; sudo cp -r dist/fan-mode /opt/fan-mode; sudo ln -s /opt/fan-mode/fan-mode /usr/bin/fan-mode; sudo cp fan-mode-recovery.service /etc/systemd/system/; sudo systemctl daemon-reload; sudo systemctl enable fan-mode-recovery; echo "Installed."; break;;
-        [Nn]* ) echo "Aborted."; exit;;
-        * ) echo "Aborted."; exit;;
-    esac
-done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pyinstaller

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-while true; do
-    read -p "Do you wish to uninstall this program? [y/N]: " yn
-    case $yn in
-        [Yy]* ) sudo rm -rf /opt/fan-mode /usr/bin/fan-mode; echo "Uninstalled."; break;;
-        [Nn]* ) echo "Aborted."; exit;;
-        * ) echo "Aborted."; exit;;
-    esac
-done


### PR DESCRIPTION
### Changes

1. Combine all the compile (build), install and uninstall scripts into one more easily maintainable Makefile.
2. Use a python virtualenv to build instead of installing pyinstaller directly to system.
3. Update docs to include updated Make related instructions.
4. Remove redundant/unnecessary files.